### PR TITLE
This should fix #6 and #7, i. e. "Package.activateConfig is deprecated" ...

### DIFF
--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -1,6 +1,9 @@
 module.exports =
-  configDefaults:
-    tidyExecutablePath: null
+  config:
+    tidyExecutablePath:
+      default: null
+      title: 'Tidy Executable Path'
+      type: 'string'
 
   activate: ->
     console.log 'activate linter-tidy'

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linter-tidy",
   "linter-package": true,
-  "activationEvents": [],
+  "activationCommands": {},
   "main": "./lib/init",
   "version": "1.0.0",
   "description": "Linter plugin for HTML, using tidy",


### PR DESCRIPTION
...and "Package.getActivationCommands is deprecated".

I used and adjusted the changes from https://github.com/AtomLinter/linter-csslint, so it should work without a problem (I didn't encounter any problems yet).