### PR TITLE
Move to eslint-config-airbnb-base and remove babel-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,26 +25,22 @@
       }
     }
   },
+  "scripts": {
+    "test": "apm test",
+    "lint": "coffeelint lib && eslint spec"
+  },
   "dependencies": {
     "atom-linter": "^4.3.2",
     "atom-package-deps": "^4.0.1"
   },
   "devDependencies": {
     "coffeelint": "^1.14.2",
-    "eslint": "^2.2.0",
-    "babel-eslint": "^6.0.2",
-    "eslint-config-airbnb": "^6.0.2"
+    "eslint": "^2.9.0",
+    "eslint-config-airbnb-base": "^2.0.0",
+    "eslint-plugin-import": "^1.6.1"
   },
   "eslintConfig": {
-    "rules": {
-      "comma-dangle": [
-        2,
-        "never"
-      ],
-      "no-console": 0
-    },
-    "extends": "airbnb/base",
-    "parser": "babel-eslint",
+    "extends": "airbnb-base",
     "globals": {
       "atom": true
     },

--- a/spec/linter-tidy-spec.js
+++ b/spec/linter-tidy-spec.js
@@ -2,12 +2,12 @@
 
 import * as path from 'path';
 
+const lint = require(path.join('..', 'lib', 'main.coffee')).provideLinter().lint;
+
 const badFile = path.join(__dirname, 'fixtures', 'bad.html');
 const goodFile = path.join(__dirname, 'fixtures', 'good.html');
 
 describe('The Tidy provider for Linter', () => {
-  const lint = require(path.join('..', 'lib', 'main.coffee')).provideLinter().lint;
-
   beforeEach(() => {
     atom.workspace.destroyActivePaneItem();
     waitsForPromise(() => {


### PR DESCRIPTION
No need for the React components of eslint-config-airbnb, and no need to use babel-eslint to parse the specs.


Closes #47.