### PR TITLE
Fixed tidy linting file on disk instead of editor text

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -30,7 +30,7 @@ module.exports =
         fileText = textEditor.getText()
         return helpers.exec(
           @executablePath,
-          ['-quiet', '-utf8', '-errors', filePath],
+          ['-quiet', '-utf8', '-errors'],
           {stream: 'stderr', stdin: fileText, allowEmptyStderr: true}
         ).then (output) ->
           messages = []

--- a/spec/linter-tidy-spec.js
+++ b/spec/linter-tidy-spec.js
@@ -64,4 +64,16 @@ describe('The Tidy provider for Linter', () => {
       )
     );
   });
+
+  it('finds errors on the fly', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(goodFile).then(editor => {
+        editor.moveToBottom();
+        editor.insertText('\n<h2>This should not be outside the body!</h2>\n');
+        return lint(editor);
+      }).then(messages => {
+        expect(messages.length).toBeGreaterThan(0);
+      })
+    );
+  });
 });


### PR DESCRIPTION
This pull request fixes a bug where the file on disk is linted instead of the contents of the editor. `tidy` will ignore stdin if a file path is passed to it as an argument, so I've removed that argument. I've tested the change on OS X and Windows, and I've added a test for on-the-fly linting.