### PR TITLE
Add support for tidyconfig file 

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -35,12 +35,28 @@ module.exports =
         fileText = textEditor.getText()
         fileDir = _path2.default.dirname(filePath)
 
-        configFile = helpers.findCached fileDir, ['.tidyrc', '.tidyconfig.cfg', '.tidyconfig.txt', 'tidyconfig.cfg', 'tidyconfig.txt']
+        configFile = helpers.findCached fileDir, [
+          '.tidyrc',
+          '.tidyconfig.cfg',
+          '.tidyconfig.txt',
+          'tidyconfig.cfg',
+          'tidyconfig.txt'
+        ]
         console.info configFile
         if configFile
-          options = ['-config', configFile, '-quiet', '-utf8', '-errors']
+          options = [
+            '-config',
+            configFile,
+            '-quiet',
+            '-utf8',
+            '-errors'
+          ]
         else
-          options = ['-quiet', '-utf8', '-errors']
+          options = [
+            '-quiet',
+            '-utf8',
+            '-errors'
+          ]
         # console.info options
         return helpers.exec(
           @executablePath,

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -20,9 +20,6 @@ module.exports =
   provideLinter: ->
     helpers = require('atom-linter')
     _path = require('path')
-    _interopRequireDefault = (obj) ->
-      if obj and obj.__esModule then obj else default: obj
-    _path2 = _interopRequireDefault(_path)
 
     regex = /line (\d+) column (\d+) - (Warning|Error): (.+)/g
     provider =
@@ -33,7 +30,7 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
-        fileDir = _path2.default.dirname(filePath)
+        fileDir = _path.dirname(filePath)
 
         configFile = helpers.findCached fileDir, [
           '.tidyrc',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -19,6 +19,11 @@ module.exports =
 
   provideLinter: ->
     helpers = require('atom-linter')
+    _path = require('path')
+    _interopRequireDefault = (obj) ->
+      if obj and obj.__esModule then obj else default: obj
+    _path2 = _interopRequireDefault(_path)
+
     regex = /line (\d+) column (\d+) - (Warning|Error): (.+)/g
     provider =
       grammarScopes: ['text.html.basic']
@@ -28,11 +33,21 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
+        fileDir = _path2.default.dirname(filePath)
+
+        configFile = helpers.findCached fileDir, ['.tidyrc', '.tidyconfig.cfg', '.tidyconfig.txt', 'tidyconfig.cfg', 'tidyconfig.txt']
+        console.info configFile
+        if configFile
+          options = ['-config', configFile, '-quiet', '-utf8', '-errors']
+        else
+          options = ['-quiet', '-utf8', '-errors']
+        # console.info options
         return helpers.exec(
           @executablePath,
-          ['-quiet', '-utf8', '-errors'],
+          options,
           {stream: 'stderr', stdin: fileText, allowEmptyStderr: true}
         ).then (output) ->
+          console.info(output)
           messages = []
           match = regex.exec(output)
           while match != null

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,28 +40,39 @@ module.exports =
       lint: (textEditor) =>
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
-        fileDir = path.dirname(filePath)
-        projectPaths = textEditor.project.getPaths() if textEditor.project.getPaths().length > 0
+        fileDir = textEditor.getDirectoryPath()
+        if textEditor.project.getPaths().length > 0
+          projectPaths = textEditor.project.getPaths()
 
         try
-          configFile = path.join fileDir, @tidyConfigName if fs.statSync path.join fileDir, @tidyConfigName
-          console.debug 'Using tidy config file at: ' + path.join fileDir, @tidyConfigName if atom.devMode
+          if fs.statSync path.join fileDir, @tidyConfigName
+            configFile = path.join fileDir, @tidyConfigName
+            if atom.devMode
+              console.debug 'Using tidy config file at: ' +
+              path.join fileDir, @tidyConfigName
         catch err
-          console.debug 'No tidy config file found at ' + path.join fileDir, @tidyConfigName + ', trying project root' if atom.devMode
+          if atom.devMode
+            console.debug 'No tidy config file found at ' +
+            path.join fileDir, @tidyConfigName + ', trying project root'
 
           if projectPaths and !configFile
             for projectPath of projectPaths
               thisPath = projectPaths[projectPath]
               if !configFile
                 try
-                  configFile = path.join thisPath, @tidyConfigName if fs.statSync path.join thisPath, @tidyConfigName
-                  console.debug 'Using tidy config file at: ' + path.join thisPath, @tidyConfigName if atom.devMode
+                  if fs.statSync path.join thisPath, @tidyConfigName
+                    configFile = path.join thisPath, @tidyConfigName
+                    if atom.devMode
+                      console.debug 'Using tidy config file at: ' +
+                      path.join thisPath, @tidyConfigName
                 catch err
                   if parseInt projectPath, 10 == projectPaths.length - 1
                     msg = ', tidy defaults will be used'
                   else
                     msg = ', trying next project folder'
-                  console.debug 'No tidy config file found at ' + path.join thisPath, @tidyConfigName + msg if atom.devMode
+                  if atom.devMode
+                    console.debug 'No tidy config file found at ' +
+                    path.join thisPath, @tidyConfigName + msg
 
 
         configFile = helpers.findCached fileDir, @tidyConfigName

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -8,8 +8,12 @@ module.exports =
       type: 'string'
     tidyConfigName:
       default: '.tidycfg.cfg'
-      title: 'Name for `tidycfg` file at the root of project directories (For custom html5-tidy config directives)'
-      description: 'See the [tidy-html5 API reference](http://api.html-tidy.org/tidy/quickref_5.2.0.html#doctype) for configuration options'
+      title: 'Name for `tidycfg` file ' +
+      '(located at the root of project directories, or with files in a folder)'
+      description: 'See the ' +
+        '[tidy-html5 API reference]' +
+        '(http://api.html-tidy.org/tidy/quickref_5.2.0.html#doctype) '+
+        'for configuration options'
       type: 'string'
 
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -7,8 +7,8 @@ module.exports =
       title: 'Full path to the `tidy` executable'
       type: 'string'
     tidyConfigName:
-      default: '.tidycfg.cfg'
-      title: 'Name for `tidycfg` file ' +
+      default: '.tidyconfig.cfg'
+      title: 'Name for `tidyconfig` file ' +
       '(located at the root of project directories, or with files in a folder)'
       description: 'See the ' +
         '[tidy-html5 API reference]' +
@@ -45,30 +45,30 @@ module.exports =
         filePath = textEditor.getPath()
         fileText = textEditor.getText()
         fileDir = textEditor.getDirectoryPath()
-        if textEditor.project.getPaths().length > 0
-          projectPaths = textEditor.project.getPaths()
+        projectPaths = textEditor.project.getPaths() if textEditor.project
 
         try
-          if fs.statSync path.join fileDir, @tidyConfigName
-            configFile = path.join fileDir, @tidyConfigName
+          fileConfigFile = path.join fileDir, @tidyConfigName
+          if fs.statSync fileConfigFile
+            configFile = fileConfigFile
             if atom.devMode
-              console.debug 'Using tidy config file at: ' +
-              path.join fileDir, @tidyConfigName
+              console.debug 'Using tidy config file at: ' + fileConfigFile
         catch err
           if atom.devMode
             console.debug 'No tidy config file found at ' +
-            path.join fileDir, @tidyConfigName + ', trying project root'
+            fileConfigFile + ', trying project root'
 
           if projectPaths and !configFile
             for projectPath of projectPaths
               thisPath = projectPaths[projectPath]
               if !configFile
                 try
-                  if fs.statSync path.join thisPath, @tidyConfigName
-                    configFile = path.join thisPath, @tidyConfigName
+                  projectConfigFile = path.join thisPath, @tidyConfigName
+                  if fs.statSync projectConfigFile
+                    configFile = projectConfigFile
                     if atom.devMode
                       console.debug 'Using tidy config file at: ' +
-                      path.join thisPath, @tidyConfigName
+                      projectConfigFile
                 catch err
                   if parseInt projectPath, 10 == projectPaths.length - 1
                     msg = ', tidy defaults will be used'
@@ -76,10 +76,7 @@ module.exports =
                     msg = ', trying next project folder'
                   if atom.devMode
                     console.debug 'No tidy config file found at ' +
-                    path.join thisPath, @tidyConfigName + msg
-
-
-        configFile = helpers.findCached fileDir, @tidyConfigName
+                    projectConfigFile + msg
 
         options = [
           '-quiet',

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -16,7 +16,6 @@ module.exports =
         'for configuration options'
       type: 'string'
 
-
   activate: ->
     require('atom-package-deps').install()
     @subscriptions = new CompositeDisposable
@@ -34,7 +33,6 @@ module.exports =
     helpers = require('atom-linter')
     path = require('path')
     fs = require('fs')
-
     regex = /line (\d+) column (\d+) - (Warning|Error): (.+)/g
     provider =
       grammarScopes: ['text.html.basic']
@@ -46,7 +44,6 @@ module.exports =
         fileText = textEditor.getText()
         fileDir = textEditor.getDirectoryPath()
         projectPaths = textEditor.project.getPaths() if textEditor.project
-
         try
           fileConfigFile = path.join fileDir, @tidyConfigName
           if fs.statSync fileConfigFile
@@ -57,7 +54,6 @@ module.exports =
           if atom.devMode
             console.debug 'No tidy config file found at ' +
             fileConfigFile + ', trying project root'
-
           if projectPaths and !configFile
             for projectPath of projectPaths
               thisPath = projectPaths[projectPath]
@@ -77,15 +73,9 @@ module.exports =
                   if atom.devMode
                     console.debug 'No tidy config file found at ' +
                     projectConfigFile + msg
-
-        options = [
-          '-quiet',
-          '-utf8',
-          '-errors'
-        ]
+        options = ['-quiet', '-utf8', '-errors']
         if configFile
           options.unshift '-config', configFile
-
         return helpers.exec(
           @executablePath,
           options,


### PR DESCRIPTION
Adds support for tidyconfig file in same folder as current file, or in the project root.
Config file name can be set in the package settings, and defaults to:

*   .tidyconfig.cfg

Fixes #40.