### PR TITLE
Docs: Update link to Tidy website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # linter-tidy
 
-This package will lint your `.html` opened files in Atom through [tidy-html5](http://www.htacg.org/tidy-html5).
+This package will lint your `.html` opened files in Atom through [tidy-html5][].
 
 ## Installation
 
-*   Install [tidy-html5](http://www.htacg.org/tidy-html5)
+*   Install [tidy-html5][]
 *   `$ apm install linter-tidy`
 
 ## Settings
@@ -16,3 +16,5 @@ Config in Atom menu):
 'linter-tidy':
   'tidyExecutablePath': null # tidy path. run 'which tidy' to find the path
 ```
+
+[tidy-html5]: http://www.html-tidy.org


### PR DESCRIPTION
The current link to the Tidy website redirects to the page this pull request links to.