### PR TITLE
chore(package): update eslint-plugin-import to version 1.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "coffeelint": "^1.14.2",
     "eslint": "^3.2.0",
     "eslint-config-airbnb-base": "^5.0.1",
-    "eslint-plugin-import": "^1.12.0"
+    "eslint-plugin-import": "^1.14.0"
   },
   "eslintConfig": {
     "extends": "airbnb-base",


### PR DESCRIPTION
https://greenkeeper.io/

Our current minimum of v1.12.0 doesn't meet the `peerDependency` of [v1.13.0](https://github.com/airbnb/javascript/blob/eslint-config-airbnb-base-v5.0.3/packages/eslint-config-airbnb-base/package.json#L59) on `eslint-config-airbnb-base`.