### PR TITLE
Update CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,20 @@
 ### Project specific config ###
+language: generic
+
 before_install:
   - brew update
 
 install:
   - brew install tidy-html5
 
-env:
-  global:
-    - ATOM_LINT_WITH_BUNDLED_NODE="false"
-  matrix:
-    - ATOM_CHANNEL=stable
-    - ATOM_CHANNEL=beta
-
 os:
   - osx
 
-# Installed for linting the project
-language: node_js
-node_js: "6"
-
 ### Generic setup follows ###
-script: 'curl -s https://raw.githubusercontent.com/atom/ci/master/build-package.sh | sh'
+script:
+  - curl -s -O https://raw.githubusercontent.com/atom/ci/master/build-package.sh
+  - chmod u+x build-package.sh
+  - ./build-package.sh
 
 notifications:
   email:


### PR DESCRIPTION
A few updates, including:

* Fix the script execution from atom/ci
* Remove beta channel build
* Use bundled Node.js to install/run the linters as it is good enough now