### PR TITLE
Added configurable Tidy executable arguments

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,9 +7,11 @@ import { dirname } from 'path';
 
 // Local variables
 const regex = /line (\d+) column (\d+) - (Warning|Error): (.+)/g;
+const defaultExecutableArguments = ['-quiet', '-errors', '--tab-size', '1'];
 // Settings
 const grammarScopes = [];
 let executablePath;
+let configExecutableArguments;
 
 export default {
   activate() {
@@ -19,6 +21,12 @@ export default {
     this.subscriptions.add(
       atom.config.observe('linter-tidy.executablePath', (value) => {
         executablePath = value;
+      })
+    );
+
+    this.subscriptions.add(
+      atom.config.observe('linter-tidy.executableArguments', (value) => {
+        configExecutableArguments = value;
       })
     );
 
@@ -46,7 +54,7 @@ export default {
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
 
-        const parameters = ['-quiet', '-utf8', '-errors', '--tab-size', '1'];
+        const parameters = defaultExecutableArguments.concat(configExecutableArguments);
 
         const [projectPath] = atom.project.relativizePath(filePath);
         const execOptions = {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,20 @@
     "executablePath": {
       "default": "tidy",
       "title": "Full path to the `tidy` executable",
+      "order": 1,
       "type": "string"
+    },
+    "executableArguments": {
+      "default": [
+        "-utf8"
+      ],
+      "title": "Tidy Executable Arguments",
+      "description": "A comma-separated list of additional arguments to pass to the Tidy executable when invoked.<br/><br/>The arguments specified here will be appended to arguments required for this linter to work.",
+      "order": 2,
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
     },
     "grammarScopes": {
       "default": [
@@ -25,6 +38,7 @@
       ],
       "title": "Grammar Scopes",
       "description": "A list of grammar scopes to lint with Tidy.<br/><br/> By default, this package only lints HTML scopes known to work cleanly with Tidy. If you know of any HTML variants that Tidy works with without producing spurious errors, please [let us know](https://github.com/AtomLinter/linter-tidy/issues) so that we may improve the default list.<br/><br/> To find the grammar scopes used by a file, use the `Editor: Log Cursor Scope` command.",
+      "order": 3,
       "type": "array",
       "items": {
         "type": "string"

--- a/spec/linter-tidy-spec.js
+++ b/spec/linter-tidy-spec.js
@@ -84,4 +84,37 @@ describe('The Tidy provider for Linter', () => {
       )
     );
   });
+
+  describe('allows for custom executable arguments and', () => {
+    it('ignores errors that a user has chosen to ignore', () => {
+      expect(atom.config.set('linter-tidy.executableArguments', [
+        '-utf8',
+        '--show-warnings',
+        'false',
+      ])).toBe(true);
+      waitsForPromise(() =>
+        atom.workspace.open(badFile).then(
+          editor => lint(editor)
+        ).then(
+          messages => expect(messages.length).toBe(0)
+        )
+      );
+    });
+
+    it('works as expected with an empty array of custom arguments', () => {
+      expect(atom.config.set('linter-tidy.executableArguments', [])).toBe(true);
+      waitsForPromise(() => Promise.all([
+        atom.workspace.open(goodFile).then(
+          editor => lint(editor)
+        ).then(
+          messages => expect(messages.length).toBe(0)
+        ),
+        atom.workspace.open(badFile).then(
+          editor => lint(editor)
+        ).then(
+          messages => expect(messages.length).toBeGreaterThan(0)
+        ),
+      ]));
+    });
+  });
 });


### PR DESCRIPTION
This pull request adds configurable executable arguments as requested by #40 and #89. (Funnily enough, I started noodling around with this a few days before #89 came in.)

I manually tested the two new options with all combinations of default and custom values and verified the correct arguments were passed to `tidy`. If you have any suggestions for automated tests I could write, I'd be happy to hear them. I'm not sure what the best method is for mocking Atom settings.
