### PR TITLE
Fixed mismatched columns between Atom and Tidy when file uses tabs

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,7 +46,7 @@ export default {
         const filePath = textEditor.getPath();
         const fileText = textEditor.getText();
 
-        const parameters = ['-quiet', '-utf8', '-errors'];
+        const parameters = ['-quiet', '-utf8', '-errors', '--tab-size', '1'];
 
         const [projectPath] = atom.project.relativizePath(filePath);
         const execOptions = {

--- a/spec/fixtures/bad_tab.html
+++ b/spec/fixtures/bad_tab.html
@@ -1,0 +1,17 @@
+<!--
+Source: https://gist.github.com/cocopon/b2b37e83922a72e809fac5623d1a0190
+See: https://github.com/AtomLinter/linter-tidy/issues/91
+-->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title></title>
+</head>
+<body>
+	<div>
+		foobar
+	</p>
+</body>
+</html>

--- a/spec/linter-tidy-spec.js
+++ b/spec/linter-tidy-spec.js
@@ -5,6 +5,7 @@ import * as path from 'path';
 const lint = require('../lib/main.js').provideLinter().lint;
 
 const badFile = path.join(__dirname, 'fixtures', 'bad.html');
+const badTabFile = path.join(__dirname, 'fixtures', 'bad_tab.html');
 const goodFile = path.join(__dirname, 'fixtures', 'good.html');
 
 describe('The Tidy provider for Linter', () => {
@@ -58,6 +59,16 @@ describe('The Tidy provider for Linter', () => {
         lint(editor).then(messages =>
           expect(messages.length).toBe(0)
         )
+      )
+    );
+  });
+
+  it('handles files indented with tabs', () => {
+    waitsForPromise(() =>
+      atom.workspace.open(badTabFile).then(
+        editor => lint(editor)
+      ).then(
+        messages => expect(messages.length).toBeGreaterThan(0)
       )
     );
   });


### PR DESCRIPTION
This resolves #91 by having Tidy count tabs as 1 space instead of the default 8. This brings its column system in line with Atom's, which treats tabs as 1 column.
