### PR TITLE
Fixed package not working on non-English systems

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -7,7 +7,12 @@ import { dirname } from 'path';
 
 // Local variables
 const regex = /line (\d+) column (\d+) - (Warning|Error): (.+)/g;
-const defaultExecutableArguments = ['-quiet', '-errors', '--tab-size', '1'];
+const defaultExecutableArguments = [
+  '-language', 'en',
+  '-quiet',
+  '-errors',
+  '--tab-size', '1',
+];
 // Settings
 const grammarScopes = [];
 let executablePath;


### PR DESCRIPTION
Because Tidy only offers error output as lines of human-readable strings, this package uses a regular expression to parse each line. Unfortunately, this means that if the locale changes to use a non-English language, the regular expression breaks.

This commit fixes the issue in the short term by forcing Tidy to use English via an executable argument.

In the long term, the ideal solution would involve parsing a more machine-friendly output format so that error messages could be given in the user's preferred language. However, this requires work be done on Tidy itself.

Fixes #101.