### PR TITLE
Whitelist Greenkeeper branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ notifications:
 branches:
   only:
     - master
+    - /^greenkeeper/.*$/
 
 git:
   depth: 10


### PR DESCRIPTION
Whitelist the Greenkeeper branches so it can fully test dependency updates.